### PR TITLE
Fix `Converters::CSV.each_host_rows` yielded value

### DIFF
--- a/lib/ronin/nmap/converters/csv.rb
+++ b/lib/ronin/nmap/converters/csv.rb
@@ -75,7 +75,7 @@ module Ronin
           yield HEADER
 
           xml.each_host do |host|
-            each_host_rows(host) do |*row|
+            each_host_rows(host) do |row|
               yield row
             end
           end
@@ -102,7 +102,7 @@ module Ronin
           ]
 
           host.each_port do |port|
-            yield([*host_row, *port_to_row(port)])
+            yield(host_row + port_to_row(port))
           end
         end
 

--- a/lib/ronin/nmap/converters/csv.rb
+++ b/lib/ronin/nmap/converters/csv.rb
@@ -102,7 +102,7 @@ module Ronin
           ]
 
           host.each_port do |port|
-            yield(*host_row, *port_to_row(port))
+            yield([*host_row, *port_to_row(port)])
           end
         end
 


### PR DESCRIPTION
`yield('foo', 'bar', 'baz')` will yield `'foo'`
`yield(['foo', 'bar', 'baz'])` will yield `[foo', 'bar', 'baz']`